### PR TITLE
fix: Update Keycloak configuration and enhance logging in AuthService

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,9 @@ KEYCLOAK_AUTH_SERVER_URL=https://keycloak.example.com
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=secret
 KEYCLOAK_REALM=studyconnect
-KEYCLOAK_DEFAULT_CLIENT_ROLE=${STUDYCONNECT_REQUIRED_ROLE} # default role assigned to new users
-KEYCLOAK_DEFAULT_ADMIN_ROLE=admin # default role assigned to new admins
-KEYCLOAK_ISSUER_URI=${KEYCLOAK_AUTH_SERVER_URL}/realms/${KEYCLOAK_REALM} # Issuer URI for JWT validation
+# default role assigned to new users
+KEYCLOAK_DEFAULT_CLIENT_ROLE=${STUDYCONNECT_REQUIRED_ROLE}
+# default role assigned to new admins
+KEYCLOAK_DEFAULT_ADMIN_ROLE=admin
+# Issuer URI for JWT validation
+KEYCLOAK_ISSUER_URI=${KEYCLOAK_AUTH_SERVER_URL}/realms/${KEYCLOAK_REALM}

--- a/backend/src/main/java/de/softwaretesting/studyconnect/services/KeycloakService.java
+++ b/backend/src/main/java/de/softwaretesting/studyconnect/services/KeycloakService.java
@@ -3,6 +3,7 @@ package de.softwaretesting.studyconnect.services;
 import de.softwaretesting.studyconnect.dtos.response.KeycloakUserResponseDTO;
 import de.softwaretesting.studyconnect.exceptions.BadRequestException;
 import de.softwaretesting.studyconnect.exceptions.InternalServerErrorException;
+import jakarta.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /** Service for Keycloak-related operations. */
@@ -51,6 +53,28 @@ public class KeycloakService {
 
   @Value("${ALLOWED_ORIGIN}")
   private String allowedOrigin;
+
+  @PostConstruct
+  void normalizeConfig() {
+    realmName = normalize("keycloak.realm", realmName);
+    defaultClientRole = normalize("keycloak.default-client-role", defaultClientRole);
+    defaultAdminRole = normalize("keycloak.default-admin-role", defaultAdminRole);
+    clientId = normalize("keycloak.client-id", clientId);
+    developmentClientId = normalize("keycloak.development.client-id", developmentClientId);
+    allowedOrigin = normalize("allowed.origin", allowedOrigin);
+    keycloakServerUrl = normalize("KEYCLOAK_AUTH_SERVER_URL", keycloakServerUrl);
+  }
+
+  private String normalize(String name, String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (!trimmed.equals(value)) {
+      LOGGER.warn("Config value '{}' has surrounding whitespace; trimming.", name);
+    }
+    return trimmed;
+  }
 
   /**
    * Returns a valid access token from the token service.
@@ -114,14 +138,35 @@ public class KeycloakService {
   public boolean addRolesToRealm(List<String> roles) {
     String roleUrl = keycloakServerUrl + KEYCLOAK_REALM_PATH + realmName + "/roles";
 
-    LOGGER.info("Roles to add: {}", roles);
+    List<String> normalizedRoles =
+        roles == null
+            ? List.of()
+            : roles.stream()
+                .filter(r -> r != null && !r.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+
+    LOGGER.info("Roles to add: {}", normalizedRoles);
     List<String> existingRoles = getAllRoles();
     try {
-      for (String roleName : roles) {
+      for (String roleName : normalizedRoles) {
         if (existingRoles.contains(roleName)) {
           LOGGER.info("Role '{}' already exists in realm '{}'", roleName, realmName);
           continue; // Role already exists
         }
+
+        boolean whitespaceVariantExists =
+            existingRoles.stream()
+                .filter(r -> r != null && !r.isBlank())
+                .anyMatch(r -> r.trim().equals(roleName));
+        if (whitespaceVariantExists) {
+          LOGGER.warn(
+              "Role '{}' exists with surrounding whitespace in realm '{}'; creating normalized role name.",
+              roleName,
+              realmName);
+        }
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(getAccessToken());
@@ -129,8 +174,17 @@ public class KeycloakService {
         Map<String, Object> body = Map.of("name", roleName);
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
-        restTemplate.postForEntity(roleUrl, request, Void.class);
-        LOGGER.info("Role '{}' added successfully to realm '{}'", roleName, realmName);
+        try {
+          restTemplate.postForEntity(roleUrl, request, Void.class);
+          LOGGER.info("Role '{}' added successfully to realm '{}'", roleName, realmName);
+        } catch (HttpClientErrorException e) {
+          if (e.getStatusCode().equals(HttpStatus.CONFLICT)) {
+            LOGGER.info(
+                "Role '{}' already exists in realm '{}' (409 CONFLICT)", roleName, realmName);
+            continue;
+          }
+          throw e;
+        }
       }
       return true;
     } catch (Exception e) {
@@ -227,8 +281,6 @@ public class KeycloakService {
             surname,
             "lastName",
             lastname,
-            "realmRoles",
-            List.of(defaultClientRole),
             "credentials",
             List.of(credentials));
 
@@ -244,6 +296,21 @@ public class KeycloakService {
           response.getStatusCode());
       boolean isSuccessful = response.getStatusCode().is2xxSuccessful();
       LOGGER.debug("Status code is2xxSuccessful: {}", isSuccessful);
+
+      String createdUserId = extractUserIdFromLocation(response);
+      LOGGER.info("Created user ID from Location: " + createdUserId);
+      if (createdUserId == null) {
+        // Fallback to lookup by email (Keycloak sometimes omits Location in some proxy setups)
+        KeycloakUserResponseDTO createdUser = retrieveUserByEmail(email);
+        createdUserId = createdUser != null ? createdUser.getKeycloakUUID() : null;
+      }
+
+      if (createdUserId == null) {
+        throw new InternalServerErrorException(
+            "User created in Keycloak but could not determine user id for role assignment");
+      }
+
+      assignRealmRolesToUser(createdUserId, List.of(defaultClientRole));
 
     } catch (HttpClientErrorException e) {
       // Translate 409 conflicts into a BadRequestException so callers can return 4xx
@@ -297,8 +364,6 @@ public class KeycloakService {
             surname,
             "lastName",
             lastname,
-            "realmRoles",
-            List.of(defaultClientRole, defaultAdminRole),
             "credentials",
             List.of(credentials));
 
@@ -308,6 +373,21 @@ public class KeycloakService {
       ResponseEntity<Void> response = restTemplate.postForEntity(userUrl, request, Void.class);
       LOGGER.info(
           "Admin user '{}' '{}' created successfully in realm '{}'", surname, lastname, realmName);
+
+      String createdUserId = extractUserIdFromLocation(response);
+      LOGGER.info("Created admin user ID from Location: " + createdUserId);
+      if (createdUserId == null) {
+        KeycloakUserResponseDTO createdUser = retrieveUserByEmail(email);
+        createdUserId = createdUser != null ? createdUser.getKeycloakUUID() : null;
+      }
+      if (createdUserId != null) {
+        assignRealmRolesToUser(createdUserId, List.of(defaultClientRole, defaultAdminRole));
+      } else {
+        LOGGER.warn(
+            "Admin user created but could not determine user id for role assignment (email={})",
+            email);
+      }
+
       return response.getStatusCode().is2xxSuccessful();
 
     } catch (HttpClientErrorException e) {
@@ -327,6 +407,146 @@ public class KeycloakService {
       throw new InternalServerErrorException(
           "Unknown error during admin user creation in Keycloak: " + e.getMessage());
     }
+  }
+
+  /**
+   * Extracts the user ID from the Location header of a Keycloak create user response.
+   *
+   * @param response the response entity from the create user request
+   * @return the extracted user ID, or null if it cannot be determined
+   */
+  private String extractUserIdFromLocation(ResponseEntity<Void> response) {
+    if (response == null || response.getHeaders() == null) {
+      return null;
+    }
+    var location = response.getHeaders().getLocation();
+    if (location == null) {
+      return null;
+    }
+    try {
+      UriComponents components = UriComponentsBuilder.fromUri(location).build();
+      List<String> segments = components.getPathSegments();
+      if (segments.isEmpty()) {
+        return null;
+      }
+      return segments.get(segments.size() - 1);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse Keycloak Location header '{}': {}", location, e.getMessage());
+      return null;
+    }
+  }
+
+  private void assignRealmRolesToUser(String userId, List<String> roleNames) {
+    if (roleNames == null || roleNames.isEmpty()) {
+      return;
+    }
+
+    List<String> normalizedRoleNames =
+        roleNames.stream()
+            .filter(r -> r != null && !r.isBlank())
+            .map(String::trim)
+            .distinct()
+            .toList();
+    if (normalizedRoleNames.isEmpty()) {
+      return;
+    }
+
+    String url =
+        keycloakServerUrl
+            + KEYCLOAK_REALM_PATH
+            + realmName
+            + "/users/"
+            + userId
+            + "/role-mappings/realm";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(getAccessToken());
+
+    List<Map<String, Object>> availableRoles = getAllRoleRepresentations();
+    List<Map<String, Object>> roleRepresentations =
+        normalizedRoleNames.stream()
+            .map(roleName -> findRoleRepresentation(availableRoles, roleName))
+            .toList();
+
+    HttpEntity<List<Map<String, Object>>> request = new HttpEntity<>(roleRepresentations, headers);
+
+    try {
+      restTemplate.postForEntity(url, request, Void.class);
+      LOGGER.info(
+          "Assigned realm roles {} to user {} in realm {}", normalizedRoleNames, userId, realmName);
+    } catch (Exception e) {
+      LOGGER.error(
+          "Failed to assign roles {} to user {}: {}", normalizedRoleNames, userId, e.getMessage());
+      throw new InternalServerErrorException(
+          "Failed to assign Keycloak roles to user: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Retrieves all role representations from the configured realm.
+   *
+   * @return list of role representations
+   */
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> getAllRoleRepresentations() {
+    String rolesUrl = keycloakServerUrl + KEYCLOAK_REALM_PATH + realmName + "/roles";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(getAccessToken());
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<List> response =
+          restTemplate.exchange(
+              rolesUrl, org.springframework.http.HttpMethod.GET, request, List.class);
+      List<Map<String, Object>> roles =
+          (List<Map<String, Object>>) (response.getBody() != null ? response.getBody() : List.of());
+      return roles;
+    } catch (Exception e) {
+      LOGGER.error("Error retrieving all roles for realm '{}': {}", realmName, e.getMessage());
+      throw new InternalServerErrorException(
+          "Failed to retrieve Keycloak roles: " + e.getMessage());
+    }
+  }
+
+  private Map<String, Object> findRoleRepresentation(
+      List<Map<String, Object>> availableRoles, String normalizedRoleName) {
+    if (normalizedRoleName == null || normalizedRoleName.isBlank()) {
+      throw new InternalServerErrorException("Role name is blank");
+    }
+
+    Map<String, Object> exact =
+        availableRoles.stream()
+            .filter(m -> normalizedRoleName.equals(m.get("name")))
+            .findFirst()
+            .orElse(null);
+
+    Map<String, Object> trimmedMatch =
+        exact != null
+            ? exact
+            : availableRoles.stream()
+                .filter(
+                    m -> {
+                      Object name = m.get("name");
+                      return name instanceof String
+                          && ((String) name).trim().equals(normalizedRoleName);
+                    })
+                .findFirst()
+                .orElse(null);
+
+    if (trimmedMatch == null) {
+      throw new InternalServerErrorException(
+          "Role '" + normalizedRoleName + "' not found in Keycloak realm '" + realmName + "'");
+    }
+
+    Object id = trimmedMatch.get("id");
+    Object name = trimmedMatch.get("name");
+    if (!(id instanceof String) || !(name instanceof String)) {
+      throw new InternalServerErrorException(
+          "Invalid role representation for '" + normalizedRoleName + "' from Keycloak");
+    }
+    return Map.of("id", id, "name", name);
   }
 
   /**

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -228,7 +228,7 @@ export class AuthService {
       resourceRoles[client] = Array.isArray(roles) ? roles : [];
     }
 
-    console.info('[AuthService]', context, {
+    console.log('[AuthService]', context, {
       authenticated: this.keycloak.authenticated ?? false,
       realm: environment.realmName,
       clientId: environment.clientID,

--- a/frontend/src/environments/environment.development.ts
+++ b/frontend/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  debugAuth: false,
+  debugAuth: true,
   apiBasePath: 'http://localhost:8088',
   apiUrl: 'http://localhost:8088/api',
   registerUserEndpoint: 'http://localhost:8088/api/users',


### PR DESCRIPTION
This pull request makes significant improvements to how Keycloak user and role management is handled in the backend service. The main focus is on normalizing configuration and role names, ensuring roles are assigned to users after creation (rather than during), and making the code more robust against whitespace and Keycloak quirks. The tests have also been updated to reflect these changes.

**Key improvements and changes:**

### Keycloak Role and User Management

* User and admin creation methods (`createUserInRealm`, `createAdminUserInRealm`) now assign realm roles after user creation, instead of including roles in the initial user payload. This allows for more reliable and explicit role assignment, especially in cases where roles may have whitespace or require normalization. [[1]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcL230-L231) [[2]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcR300-R314) [[3]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcL300-L301)
* Added normalization for configuration values and role names to prevent issues with accidental whitespace. This includes a `normalizeConfig` method (run on startup) and normalization logic in role assignment. [[1]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcR57-R78) [[2]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcL117-R187)
* Improved handling of Keycloak's response to user creation: the user ID is now extracted from the `Location` header, with a fallback to lookup by email if necessary. This makes the process more robust, especially in proxy or non-standard deployments. [[1]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcR300-R314) [[2]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcR376-R390) [[3]](diffhunk://#diff-38920c9a6cc14a89639cc360bf4292f40de15cf681778dfc5fcaf8e073a64bfcR412-R551)

### Test Updates

* Updated tests to expect roles to be assigned after user creation, not in the initial payload, and to mock the new role assignment HTTP requests. [[1]](diffhunk://#diff-60a0ce3db0ca2adc83e7b8991ad3367be73fd145684cd765b6dfb15ead23eceaL208-R249) [[2]](diffhunk://#diff-60a0ce3db0ca2adc83e7b8991ad3367be73fd145684cd765b6dfb15ead23eceaR258-R275) [[3]](diffhunk://#diff-60a0ce3db0ca2adc83e7b8991ad3367be73fd145684cd765b6dfb15ead23eceaL240-R285) [[4]](diffhunk://#diff-60a0ce3db0ca2adc83e7b8991ad3367be73fd145684cd765b6dfb15ead23eceaL275-R351) [[5]](diffhunk://#diff-60a0ce3db0ca2adc83e7b8991ad3367be73fd145684cd765b6dfb15ead23eceaL291-R365)

### Configuration and Documentation

* Improved `.env.example` formatting and comments for clarity, separating comments from variable values.

---

These changes make the Keycloak integration more reliable, especially in environments where role names or configuration might include unwanted whitespace, and ensure that user role assignments are explicit and robust.